### PR TITLE
Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,16 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.8
-    - george-edison55-precise-backports
     packages:
-    - g++-5
-    - clang-3.8
-    - cmake
-    - cmake-data
 matrix:
     include:
         - name: Linux (gcc-5)
           os: linux
+          dist: xenial
           compiler: gcc
         - name: Linux (clang)
           os: linux
+          dist: xenial
           compiler: clang
 before_install:
   - $CC --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: c
 sudo: false
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: cpp
-compiler:
-  - clang
-  - gcc
 sudo: false
 addons:
   apt:
@@ -14,9 +11,15 @@ addons:
     - clang-3.8
     - cmake
     - cmake-data
+matrix:
+    include:
+        - name: Linux (gcc-5)
+          os: linux
+          compiler: gcc
+        - name: Linux (clang)
+          os: linux
+          compiler: clang
 before_install:
-  - $CC --version
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; else export CXX="clang++-3.8" CC="clang-3.8"; fi
   - $CC --version
   - cmake --version
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,17 @@ language: cpp
 sudo: false
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
 matrix:
     include:
-        - name: Linux (gcc-5)
+        - name: Linux (gcc-8)
           os: linux
           dist: xenial
-          compiler: gcc
+          compiler: gcc-8
+          addons:
+             apt:
+               sources:
+                 - ubuntu-toolchain-r-test
+               packages: g++-8
         - name: Linux (clang)
           os: linux
           dist: xenial


### PR DESCRIPTION
Update travis to use Xenial (Ubuntu 16.04)
Update to use also gcc-8 and clang-7

There is some warning about -Wimplicit-fallthrough
```
lsqpack.c:3236:16: warning: this statement may fall through [-Wimplicit-fallthrough=]
lsqpack.c:3250:16: warning: this statement may fall through [-Wimplicit-fallthrough=]
```