### PR TITLE
Refactor build to use modern CMake features

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,21 +1,13 @@
 version: 1.0.{build}
 
+before_build:
+  - cmake .
+
 build_script:
+  - cmake --build .
 
-- cmd: >-
-
-    cmake .
-
-
-
-    msbuild ALL_BUILD.vcxproj
+before_test:
+  - set PATH=%PATH%;c:\projects\ls-qpack\bin\Debug
 
 test_script:
-
-- cmd: >-
-
-    set path=%path%;c:\projects\ls-qpack\bin\Debug
-
-
-
-    msbuild RUN_TESTS.vcxproj
+  - ctest 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,4 +3,4 @@ freebsd_instance:
 
 task:
     install_script: pkg install -y cmake bash perl5
-    script: cmake . && make && make test
+    script: cmake -DLSQPACK_TESTS=ON . && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - $CC --version
   - cmake --version
 before_script:
-  - cmake .
+  - cmake -DLSQPACK_TESTS=ON .
 script:
   - make
   - make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,77 +1,57 @@
 # The following variable can be defined on the command line:
 #
-#   SHARED
-#   NDEBUG
-#   XXH_HEADER_NAME
-#   XXH_INCLUDE_DIR
+#   BUILD_SHARED_LIBS
+#
+# The following environment variables will be taken into account when running
+# cmake for the first time:
+#
+#   CFLAGS
+#   LDFLAGS
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
-PROJECT(ls-qpack)
+cmake_minimum_required(VERSION 3.1)
+project(ls-qpack LANGUAGES C)
 
-IF (SHARED EQUAL 1)
-    ADD_LIBRARY(ls-qpack SHARED src/lsqpack.c deps/xxhash/xxhash.c)
-    ADD_LIBRARY(ls-qpack-noxxh SHARED src/lsqpack.c)
-ELSE()
-    ADD_LIBRARY(ls-qpack STATIC src/lsqpack.c deps/xxhash/xxhash.c)
-    ADD_LIBRARY(ls-qpack-noxxh STATIC src/lsqpack.c)
-ENDIF()
-INCLUDE_DIRECTORIES(include)
+option(LSQPACK_TESTS "Build tests")
 
-IF (NOT DEFINED XXH_HEADER_NAME)
-    SET(XXH_HEADER_NAME "xxhash.h")
-ENDIF()
+# Use `cmake -DBUILD_SHARED_LIBS=OFF` to build a static library.
+add_library(ls-qpack "")
+target_include_directories(ls-qpack PUBLIC include)
+target_sources(ls-qpack PRIVATE src/lsqpack.c)
 
-IF (DEFINED XXH_INCLUDE_DIR)
-    INCLUDE_DIRECTORIES("${XXH_INCLUDE_DIR}")
-ELSE()
-    INCLUDE_DIRECTORIES(deps/xxhash)
-ENDIF()
+# xxhash
+target_include_directories(ls-qpack PRIVATE deps/xxhash/)
+target_sources(ls-qpack PRIVATE deps/xxhash/xxhash.c)
 
-IF (MSVC)
-    INCLUDE_DIRECTORIES(wincompat)
-ENDIF()
+if(MSVC)
+    target_include_directories(ls-qpack PRIVATE wincompat)
+endif()
 
-IF (MSVC)
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /Wall")
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4100") # unreffed parameter
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4200") # zero-sized array
-    # Apparently this C99 construct is not supported properly by VS:
-    #   https://stackoverflow.com/questions/1064930/struct-initializer-typedef-with-visual-studio
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4204") # non-constant aggregate initializer
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4255") # no function prototype (getopt)
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4820") # padding
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4668") # undefined macro
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4710") # not inlined by default
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4996") # unsafe function
-ELSE()
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Wall -Wextra -Wno-unused-parameter")
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -fno-omit-frame-pointer")
-ENDIF()
-SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} $ENV{EXTRA_CFLAGS}")
+if(MSVC)
+    target_compile_options(ls-qpack PRIVATE
+        /Wall
+        /wd4100 # unreffed parameter
+        /wd4200 # zero-sized array
+        # Apparently this C99 construct is not supported properly by VS:
+        #   https://stackoverflow.com/questions/1064930/struct-initializer-typedef-with-visual-studio
+        /wd4204 # non-constant aggregate initializer
+        /wd4255 # no function prototype (getopt)
+        /wd4820 # padding
+        /wd4668 # undefined macro
+        /wd4710 # not inlined by default
+        /wd4996 # unsafe function
+    )
+else()
+    target_compile_options(ls-qpack PRIVATE
+        -Wall
+        -Wextra
+        -Wno-unused-parameter
+        -fno-omit-frame-pointer
+    )
+endif()
 
-IF (MSVC)
-    SET(CMAKE_C_FLAGS_DEBUG "/Od /Zi")
-    SET(CMAKE_C_FLAGS_RELEASE "/O2")
-ELSE()
-    SET(CMAKE_C_FLAGS_DEBUG "-O0 -g3")
-    SET(CMAKE_C_FLAGS_RELEASE "-O3 -g0")
-ENDIF()
+if(LSQPACK_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()
 
-IF (NDEBUG EQUAL 1)
-    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DNDEBUG")
-ENDIF()
-
-SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DXXH_HEADER_NAME=\\\"${XXH_HEADER_NAME}\\\"")
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MY_CMAKE_FLAGS}")
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} $ENV{EXTRA_LDFLAGS}")
-
-MESSAGE(STATUS "Compiler flags: ${CMAKE_C_FLAGS}")
-
-IF (NOT NDEBUG EQUAL 1)
-    ENABLE_TESTING()
-    INCLUDE_DIRECTORIES("test")
-    ADD_SUBDIRECTORY("test")
-ENDIF()
-
-ADD_SUBDIRECTORY("bin")
+add_subdirectory(bin)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,12 +1,19 @@
-ENABLE_TESTING()
+function(lsqpack_add_executable TARGET)
+    add_executable(${TARGET} "")
+    target_link_libraries(${TARGET} PRIVATE ls-qpack)
 
-IF (MSVC)
-    SET(AUX ../deps/xxhash/xxhash.c ../wincompat/getopt.c ../wincompat/getopt1.c)
-ELSE()
-    SET(AUX ../deps/xxhash/xxhash.c)
-ENDIF()
+    target_sources(${TARGET} PRIVATE ${TARGET}.c)
 
-FOREACH(BIN_NAME interop-encode interop-decode encode-int fuzz-decode)
-    ADD_EXECUTABLE(${BIN_NAME} ${BIN_NAME}.c ${AUX})
-    TARGET_LINK_LIBRARIES(${BIN_NAME} ls-qpack-noxxh)
-ENDFOREACH()
+    if(MSVC)
+        target_include_directories(${TARGET} PRIVATE ../wincompat)
+        target_sources(${TARGET} PRIVATE 
+            ../wincompat/getopt.c 
+            ../wincompat/getopt1.c
+        )
+    endif()
+endfunction()
+
+lsqpack_add_executable(interop-encode)
+lsqpack_add_executable(interop-decode)
+lsqpack_add_executable(encode-int)
+lsqpack_add_executable(fuzz-decode)

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -34,7 +34,8 @@ SOFTWARE.
 #include <inttypes.h>
 
 #include "lsqpack.h"
-#include XXH_HEADER_NAME
+
+#include <xxhash.h>
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,53 +1,73 @@
-ENABLE_TESTING()
+function(lsqpack_add_test TARGET)
+    add_executable(test_${TARGET} "")
+    target_sources(test_${TARGET} PRIVATE test_${TARGET}.c)
+    target_link_libraries(test_${TARGET} ls-qpack)
 
-IF (MSVC)
-    SET(AUX ../deps/xxhash/xxhash.c ../wincompat/getopt.c ../wincompat/getopt1.c)
-ELSE()
-    SET(AUX ../deps/xxhash/xxhash.c)
-ENDIF()
+    if(MSVC)
+        target_include_directories(test_${TARGET} PRIVATE ../wincompat)
+        target_sources(test_${TARGET} PRIVATE 
+            ../wincompat/getopt.c 
+            ../wincompat/getopt1.c
+        )
+    endif()
 
-FOREACH(TEST_NAME int enc_str huff_dec read_enc_stream qpack)
-    ADD_EXECUTABLE(test_${TEST_NAME} test_${TEST_NAME}.c ${AUX})
-    TARGET_LINK_LIBRARIES(test_${TEST_NAME} ls-qpack)
-    ADD_TEST(${TEST_NAME} test_${TEST_NAME})
-ENDFOREACH()
+    add_test(${TARGET} test_${TARGET})
+endfunction()
 
-IF (MSVC)
-    MESSAGE(WARNING "Scenario tests are disabled on Windows (TODO)")
-ELSE()
-    FILE(GLOB SCENARIOS scenarios/*.sce)
-    FOREACH(SCENARIO ${SCENARIOS})
-	GET_FILENAME_COMPONENT(TEST_NAME ${SCENARIO} NAME)
-	ADD_TEST(NAME scenario-${TEST_NAME}
-		 COMMAND bash run-scenario.sh ${SCENARIO})
-	SET_TESTS_PROPERTIES(scenario-${TEST_NAME} PROPERTIES
-		ENVIRONMENT "PATH=$ENV{PATH}:../bin:../tools")
-    ENDFOREACH()
-ENDIF()
+lsqpack_add_test(int)
+lsqpack_add_test(enc_str)
+lsqpack_add_test(huff_dec)
+lsqpack_add_test(read_enc_stream)
+lsqpack_add_test(qpack)
 
-FIND_PROGRAM(PERL NAMES perl)
+if(MSVC)
+    message(WARNING "Scenario tests are disabled on Windows (TODO)")
+else()
+    file(GLOB SCENARIOS scenarios/*.sce)
+    foreach(SCENARIO ${SCENARIOS})
+        get_filename_component(TEST_NAME ${SCENARIO} NAME)
+        add_test(
+            NAME scenario-${TEST_NAME}
+            COMMAND bash run-scenario.sh ${SCENARIO}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+        )
+        set_tests_properties(scenario-${TEST_NAME} PROPERTIES
+            ENVIRONMENT "PATH=$ENV{PATH}:${PROJECT_BINARY_DIR}/bin:${PROJECT_SOURCE_DIR}/tools"
+        )
+    endforeach()
+endif()
 
-IF (PERL STREQUAL "PERL-NOTFOUND")
-    MESSAGE(WARNING "Perl not found: QIF tests won't be run")
-ELSE()
-    MESSAGE(STATUS "Found Perl interpreter: ${PERL}")
-    FILE(GLOB QIFS qifs/*.qif)
-    FOREACH(QIF ${QIFS})
-	GET_FILENAME_COMPONENT(FILE_NAME ${QIF} NAME)
-	FOREACH(TABLE_SIZE 0 256 512 1024 4096)
-	    FOREACH(RISKED_STREAMS 0 100)
-		FOREACH(IMMEDIATE_ACK 0 1)
-		    FOREACH(AGGRESSIVE 0 1)
-			SET(TEST_NAME qif-${FILE_NAME}-t${TABLE_SIZE}-s${RISKED_STREAMS}-a${IMMEDIATE_ACK}-A${AGGRESSIVE})
-			ADD_TEST(NAME ${TEST_NAME}
-			    COMMAND ${PERL} run-qif.pl --table-size ${TABLE_SIZE} --risked-streams ${RISKED_STREAMS} --immed-ack ${IMMEDIATE_ACK} --aggressive ${AGGRESSIVE} ${QIF})
-                        IF (NOT MSVC)
-                            SET_TESTS_PROPERTIES(${TEST_NAME} PROPERTIES
-                                    ENVIRONMENT "PATH=$ENV{PATH}:../bin:../tools")
-                        ENDIF()
-                    ENDFOREACH()
-		ENDFOREACH()
-	    ENDFOREACH()
-	ENDFOREACH()
-    ENDFOREACH()
-ENDIF()
+find_package(Perl)
+
+if(PERL_FOUND)
+    message(STATUS "Found Perl interpreter: ${PERL}")
+    file(GLOB QIFS qifs/*.qif)
+    
+    foreach(QIF ${QIFS})
+        get_filename_component(FILE_NAME ${QIF} NAME)
+        
+        foreach(TABLE_SIZE 0 256 512 1024 4096)
+            foreach(RISKED_STREAMS 0 100)
+                foreach(IMMEDIATE_ACK 0 1)
+                    foreach(AGGRESSIVE 0 1)
+                        set(TEST_NAME qif-${FILE_NAME}-t${TABLE_SIZE}-s${RISKED_STREAMS}-a${IMMEDIATE_ACK}-A${AGGRESSIVE})
+                        
+                        add_test(
+                            NAME ${TEST_NAME}
+                            COMMAND ${PERL} run-qif.pl --table-size ${TABLE_SIZE} --risked-streams ${RISKED_STREAMS} --immed-ack ${IMMEDIATE_ACK} --aggressive ${AGGRESSIVE} ${QIF}
+                            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+                        )
+                        
+                        if(NOT MSVC)
+                            set_tests_properties(${TEST_NAME} PROPERTIES
+                                ENVIRONMENT "PATH=$ENV{PATH}:${PROJECT_BINARY_DIR}/bin:${PROJECT_SOURCE_DIR}/tools"
+                            )
+                        endif()
+                    endforeach()
+                endforeach()
+            endforeach()
+        endforeach()
+    endforeach()
+else()
+    message(WARNING "Perl not found: QIF tests won't be run")
+endif()


### PR DESCRIPTION
Notes:

- We now use per target commands instead of directory commands (`target_include_directories` instead of `include_directories`). By applying commands to separate targets they will also be automatically picked up by targets that depend on them. To give an example, if we do `target_include_directories(ls-qpack PUBLIC include/)` then every target that links to ls-qpack with `target_link_libraries` will automatically get the `include/` directory added to its list of include directories. 
- Switched to lowercase commands as that style is also used by the CMake documentation and seems to generally be used more then uppercase commands.
- Instead of relying on a custom variable to build static or shared, we use the built-in `BUILD_SHARED_LIBS` variable which is built-in to CMake to allow the user to build shared or static libraries.
- I removed the logic allowing for custom xxhash implementations for now to simplify the build. If it's necessary to have, we could allow users to specify a directory/location where to look for the custom implementation. Let me know if I should re-add this.
- Added a custom option (`LSQPACK_TESTS`) to decide whether to build tests or not. Disabled by default (let me know if it should be enabled by default).
- Removed support for the `EXTRA_CFLAGS` and `EXTRA_LDFLAGS` environment variables. Instead, the `CFLAGS` and `LDFLAGS` environment variables should be used which CMake automatically picks up on its first run.
- Removed custom `CMAKE_C_FLAGS_DEBUG` and `CMAKE_C_FLAGS_RELEASE` values since they are the same as the default values set by CMake (CMake uses -g instead of -g3 however).
- Removed `NDEBUG` since CMake adds it by default to `CMAKE_C_FLAGS_RELEASE`.

The qif tests didn't succeed on Windows because `strace` was not found. Are those tests supposed to work on Windows?