### PR TITLE
201903050900 improve test cov

### DIFF
--- a/test/scenarios/incl-name.sce
+++ b/test/scenarios/incl-name.sce
@@ -1,0 +1,10 @@
+TABLE_SIZE=256
+AGGRESSIVE=1
+RISKED_STREAMS=0
+QIF=$(cat<<'EOQ'
+yo	I
+no	do not
+se	know
+
+EOQ
+)

--- a/test/scenarios/incl-name.sce
+++ b/test/scenarios/incl-name.sce
@@ -1,3 +1,6 @@
+# This scenario is designed to reach 'case DATA_STATE_READ_LFONR_NAME_PLAIN'
+# in parse_header_data(). It contains header names that are be too small
+# for Huffman coding.
 TABLE_SIZE=256
 AGGRESSIVE=1
 RISKED_STREAMS=0


### PR DESCRIPTION
I added a scenario that is designed to reach `case DATA_STATE_READ_LFONR_NAME_PLAIN` in _parse_header_data()_. It contains header names that are too small for Huffman coding.