### PR TITLE
Split decode buffer to reach LQRHS_NEED cases during testing

### DIFF
--- a/bin/interop-decode.c
+++ b/bin/interop-decode.c
@@ -350,10 +350,11 @@ main (int argc, char **argv)
         }
         else
         {
+        dec_header:
             p = buf->buf + buf->off;
             if (buf->off == 0)
                 rhs = lsqpack_dec_header_in(&decoder, buf, buf->stream_id,
-                                buf->size, &p, buf->size, &hset, NULL, NULL);
+                                buf->size, &p, buf->size / 2, &hset, NULL, NULL);
             else
                 rhs = lsqpack_dec_header_read(buf->dec, buf, &p,
                                 buf->size - buf->off, &hset, NULL, NULL);
@@ -365,12 +366,9 @@ main (int argc, char **argv)
                 free(buf);
                 break;
             case LQRHS_BLOCKED:
-                buf->off += (unsigned) (p - buf->buf);
-                break;
             case LQRHS_NEED:
-                fprintf(stderr, "This can't be right: all bytes were given.  "
-                    "stream %"PRIu64"\n", buf->stream_id);
-                exit(EXIT_FAILURE);
+                buf->off += (unsigned) (p - buf->buf);
+                goto dec_header;
             default:
                 assert(rhs == LQRHS_ERROR);
                 fprintf(stderr, "stream %"PRIu64": header block error "

--- a/test/scenarios/incl-name.sce
+++ b/test/scenarios/incl-name.sce
@@ -1,0 +1,10 @@
+TABLE_SIZE=256
+AGGRESSIVE=1
+RISKED_STREAMS=0
+QIF=$(cat<<'EOQ'
+yo	I
+no	do not
+se	know
+
+EOQ
+)

--- a/test/scenarios/incl-name.sce
+++ b/test/scenarios/incl-name.sce
@@ -1,3 +1,6 @@
+# This scenario is designed to reach 'case DATA_STATE_READ_LFONR_NAME_PLAIN'
+# in parse_header_data(). It contains header names that are be too small
+# for Huffman coding.
 TABLE_SIZE=256
 AGGRESSIVE=1
 RISKED_STREAMS=0


### PR DESCRIPTION
During testing, all buffers were read to the decoder "in full." Therefore, the `LQRHS_NEED` and `HUFF_DEC_END_SRC` cases were not covered during testing.

In this commit, _interop-decode.c_ is modified so that only half of the the incoming buffer is read into the decoder to force the `LQRHS_NEED` case. A `goto` is added so that the rest of the buffer is read into the decoder shortly after.