### PR TITLE
[TEST] Split decode buffers to test LQRHS_NEED cases

### DIFF
--- a/bin/interop-decode.c
+++ b/bin/interop-decode.c
@@ -47,6 +47,12 @@ static int s_verbose;
 
 static FILE *s_out;
 
+static unsigned
+min(unsigned a, unsigned b)
+{
+    return (a < b) ? a : b;
+}
+
 static void
 usage (const char *name)
 {
@@ -62,6 +68,7 @@ usage (const char *name)
 "                 order.\n"
 "   -s NUMBER   Maximum number of risked streams.  Defaults to %u.\n"
 "   -t NUMBER   Dynamic table size.  Defaults to %u.\n"
+"   -m NUMBER   Maximum read size.  Defaults to SIZE_MAX.\n"
 "   -v          Verbose: print headers and table state to stderr.\n"
 "\n"
 "   -h          Print this help screen and exit\n"
@@ -150,7 +157,7 @@ main (int argc, char **argv)
     char command[0x100];
     char line_buf[0x100];
 
-    while (-1 != (opt = getopt(argc, argv, "i:o:r:s:t:hv")))
+    while (-1 != (opt = getopt(argc, argv, "i:o:r:s:t:m:hv")))
     {
         switch (opt)
         {
@@ -197,6 +204,9 @@ main (int argc, char **argv)
             break;
         case 't':
             dyn_table_size = atoi(optarg);
+            break;
+        case 'm':
+            s_max_read_size = atoi(optarg);
             break;
         case 'h':
             usage(argv[0]);
@@ -260,6 +270,8 @@ main (int argc, char **argv)
         buf->stream_id = stream_id;
         buf->size = size;
         buf->file_off = file_off;
+        if (buf->size == 0)
+            exit(EXIT_FAILURE);
         TAILQ_INSERT_TAIL(&bufs, buf, next_buf);
     }
 
@@ -354,10 +366,12 @@ main (int argc, char **argv)
             p = buf->buf + buf->off;
             if (buf->off == 0)
                 rhs = lsqpack_dec_header_in(&decoder, buf, buf->stream_id,
-                                buf->size, &p, buf->size / 2, &hset, NULL, NULL);
+                                buf->size, &p, min(s_max_read_size, buf->size),
+                                &hset, NULL, NULL);
             else
                 rhs = lsqpack_dec_header_read(buf->dec, buf, &p,
-                                buf->size - buf->off, &hset, NULL, NULL);
+                                min(s_max_read_size, (buf->size - buf->off)),
+                                &hset, NULL, NULL);
             switch (rhs)
             {
             case LQRHS_DONE:
@@ -366,10 +380,10 @@ main (int argc, char **argv)
                 free(buf);
                 break;
             case LQRHS_BLOCKED:
-                buf->off += (unsigned) (p - buf->buf);
+                buf->off = (unsigned) (p - buf->buf);
                 break;
             case LQRHS_NEED:
-                buf->off += (unsigned) (p - buf->buf);
+                buf->off = (unsigned) (p - buf->buf);
                 goto dec_header;
             default:
                 assert(rhs == LQRHS_ERROR);

--- a/bin/interop-decode.c
+++ b/bin/interop-decode.c
@@ -350,10 +350,11 @@ main (int argc, char **argv)
         }
         else
         {
+        dec_header:
             p = buf->buf + buf->off;
             if (buf->off == 0)
                 rhs = lsqpack_dec_header_in(&decoder, buf, buf->stream_id,
-                                buf->size, &p, buf->size, &hset, NULL, NULL);
+                                buf->size, &p, buf->size / 2, &hset, NULL, NULL);
             else
                 rhs = lsqpack_dec_header_read(buf->dec, buf, &p,
                                 buf->size - buf->off, &hset, NULL, NULL);
@@ -368,9 +369,8 @@ main (int argc, char **argv)
                 buf->off += (unsigned) (p - buf->buf);
                 break;
             case LQRHS_NEED:
-                fprintf(stderr, "This can't be right: all bytes were given.  "
-                    "stream %"PRIu64"\n", buf->stream_id);
-                exit(EXIT_FAILURE);
+                buf->off += (unsigned) (p - buf->buf);
+                goto dec_header;
             default:
                 assert(rhs == LQRHS_ERROR);
                 fprintf(stderr, "stream %"PRIu64": header block error "

--- a/test/run-qif.pl
+++ b/test/run-qif.pl
@@ -69,7 +69,7 @@ if ($^O eq 'MSWin32') {
 } else {
     system("interop-encode $encode_args -i $qif_file -o $bin_file")
         and die "interop-encode failed";
-    system("interop-decode $decode_args -i $bin_file -o $resulting_qif_file")
+    system("interop-decode $decode_args -m 1 -i $bin_file -o $resulting_qif_file")
         and die "interop-decode failed";
 }
 


### PR DESCRIPTION
During testing, all buffers were read to the decoder "in full." Therefore, the `LQRHS_NEED` and `HUFF_DEC_END_SRC` cases were not covered during testing.

In this commit, _interop-decode.c_ is modified so that only half of the the incoming buffer is read into the decoder to force the `LQRHS_NEED` case. A `goto` is added so that the rest of the buffer is read into the decoder shortly after.