### PR TITLE
Fix bug with LFPBNR reading and increase decode testing vigor

### DIFF
--- a/bin/interop-decode.c
+++ b/bin/interop-decode.c
@@ -47,11 +47,7 @@ static int s_verbose;
 
 static FILE *s_out;
 
-static unsigned
-min(unsigned a, unsigned b)
-{
-    return (a < b) ? a : b;
-}
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 static void
 usage (const char *name)
@@ -68,11 +64,11 @@ usage (const char *name)
 "                 order.\n"
 "   -s NUMBER   Maximum number of risked streams.  Defaults to %u.\n"
 "   -t NUMBER   Dynamic table size.  Defaults to %u.\n"
-"   -m NUMBER   Maximum read size.  Defaults to SIZE_MAX.\n"
+"   -m NUMBER   Maximum read size.  Defaults to %zu.\n"
 "   -v          Verbose: print headers and table state to stderr.\n"
 "\n"
 "   -h          Print this help screen and exit\n"
-    , name, LSQPACK_DEF_MAX_RISKED_STREAMS, LSQPACK_DEF_DYN_TABLE_SIZE);
+    , name, LSQPACK_DEF_MAX_RISKED_STREAMS, LSQPACK_DEF_DYN_TABLE_SIZE, SIZE_MAX);
 }
 
 
@@ -366,11 +362,11 @@ main (int argc, char **argv)
             p = buf->buf + buf->off;
             if (buf->off == 0)
                 rhs = lsqpack_dec_header_in(&decoder, buf, buf->stream_id,
-                                buf->size, &p, min(s_max_read_size, buf->size),
+                                buf->size, &p, MIN(s_max_read_size, buf->size),
                                 &hset, NULL, NULL);
             else
                 rhs = lsqpack_dec_header_read(buf->dec, buf, &p,
-                                min(s_max_read_size, (buf->size - buf->off)),
+                                MIN(s_max_read_size, (buf->size - buf->off)),
                                 &hset, NULL, NULL);
             switch (rhs)
             {

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -3306,6 +3306,7 @@ parse_header_data (struct lsqpack_dec *dec,
             {
                 prefix_bits = 3;
                 LFPBNR.is_never = buf[0] & 0x08;
+                LFPBNR.dec_int_state.resume = 0;
                 LFPBNR.value = NULL;
                 LFPBNR.reffed_entry = NULL;
                 read_ctx->hbrc_parse_ctx_u.data.state

--- a/test/run-qif.pl
+++ b/test/run-qif.pl
@@ -69,7 +69,7 @@ if ($^O eq 'MSWin32') {
 } else {
     system("interop-encode $encode_args -i $qif_file -o $bin_file")
         and die "interop-encode failed";
-    system("interop-decode $decode_args -i $bin_file -o $resulting_qif_file")
+    system("interop-decode $decode_args -m 1 -i $bin_file -o $resulting_qif_file")
         and die "interop-decode failed";
 }
 

--- a/test/run-qif.pl
+++ b/test/run-qif.pl
@@ -64,7 +64,7 @@ copy($ARGV[0], $qif_file) or die "cannot copy original $ARGV[0] to $qif_file";
 if ($^O eq 'MSWin32') {
     system('interop-encode', $encode_args, '-i', $qif_file, '-o', $bin_file)
         and die "interop-encode failed";
-    system('interop-decode', $decode_args, '-i', $bin_file, '-o', $resulting_qif_file)
+    system('interop-decode', $decode_args, '-m', '1', '-i', $bin_file, '-o', $resulting_qif_file)
         and die "interop-decode failed";
 } else {
     system("interop-encode $encode_args -i $qif_file -o $bin_file")


### PR DESCRIPTION
[BUGFIX, TEST] Reset resume before READ_LFPBNR_IDX, split decode buffers to test LQRHS_CASES.

This commit includes a bug fix to the decoder. Previously, the value of `resume` was not reset between state changes and it could lead to incorrect or missing header names.

This commit also includes changes to the the `interop-decode` test program. To increase coverage, there is a setting to limit the rate at which the decoder is fed encoded bytes. The bug described above was discovered using this rate-limit parameter during testing.