### PR TITLE
[TEST] Reach error cases in enc_end_header()

### DIFF
--- a/bin/interop-encode.c
+++ b/bin/interop-encode.c
@@ -331,8 +331,14 @@ main (int argc, char **argv)
         {
             if (header_opened)
             {
-                pref_sz = lsqpack_enc_end_header(&encoder, pref_buf,
-                                                                sizeof(pref_buf));
+                size_t sz, pref_max = sizeof(pref_buf);
+                for (size_t sz = 0; sz < pref_max; sz++)
+                {
+                    pref_sz = lsqpack_enc_end_header(&encoder, pref_buf, sz);
+                    if (pref_sz > 0)
+                        break;
+                }
+                assert(pref_sz <= lsqpack_enc_header_data_prefix_size(&encoder));
                 if (pref_sz < 0)
                 {
                     fprintf(stderr, "end_header failed: %s", strerror(errno));

--- a/bin/interop-encode.c
+++ b/bin/interop-encode.c
@@ -332,7 +332,7 @@ main (int argc, char **argv)
             if (header_opened)
             {
                 size_t sz, pref_max = sizeof(pref_buf);
-                for (size_t sz = 0; sz < pref_max; sz++)
+                for (sz = 0; sz < pref_max; sz++)
                 {
                     pref_sz = lsqpack_enc_end_header(&encoder, pref_buf, sz);
                     if (pref_sz > 0)

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -1452,6 +1452,8 @@ lsqpack_enc_end_header (struct lsqpack_enc *enc, unsigned char *buf, size_t sz)
         }
         *buf = (unsigned char) (sign << 7);
         dst = lsqpack_enc_int(buf, end, diff, 7);
+        if (dst <= buf)
+            return 0;
 
         E_DEBUG("ended header for stream %"PRIu64"; max ref: %u encoded as %u; "
             "risked: %d", hinfo->qhi_stream_id, hinfo->qhi_max_id,

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -1415,6 +1415,9 @@ lsqpack_enc_end_header (struct lsqpack_enc *enc, unsigned char *buf, size_t sz)
     lsqpack_abs_id_t diff, encoded_largest_ref;
     unsigned sign;
 
+    if (sz == 0)
+        return -1;
+
     if (!(enc->qpe_flags & LSQPACK_ENC_HEADER))
         return -1;
 
@@ -1449,8 +1452,6 @@ lsqpack_enc_end_header (struct lsqpack_enc *enc, unsigned char *buf, size_t sz)
         }
         *buf = (unsigned char) (sign << 7);
         dst = lsqpack_enc_int(buf, end, diff, 7);
-        if (dst <= buf)
-            return 0;
 
         E_DEBUG("ended header for stream %"PRIu64"; max ref: %u encoded as %u; "
             "risked: %d", hinfo->qhi_stream_id, hinfo->qhi_max_id,


### PR DESCRIPTION
Reach error cases in enc_end_header() and assert prefix size is less than lsqpack_enc_header_data_prefix_size().