### PR TITLE
[TEST] Add print_table() and enc_ratio() for testing coverage

### DIFF
--- a/bin/interop-decode.c
+++ b/bin/interop-decode.c
@@ -404,6 +404,8 @@ main (int argc, char **argv)
      * an error.
      */
 
+    lsqpack_dec_print_table(&decoder, stderr);
+
     lsqpack_dec_cleanup(&decoder);
 
     assert(TAILQ_EMPTY(&bufs));

--- a/bin/interop-encode.c
+++ b/bin/interop-encode.c
@@ -359,8 +359,7 @@ main (int argc, char **argv)
                         exit(EXIT_FAILURE);
                     }
                 }
-                if (s_verbose)
-                    fprintf(stderr, "compression ratio: %.3f\n",
+                fprintf(stderr, "compression ratio: %.3f\n",
                         lsqpack_enc_ratio(&encoder));
                 write_enc_and_header_streams(out, stream_id, enc_buf, enc_off,
                                              pref_buf, pref_sz, hea_buf, hea_off);

--- a/bin/interop-encode.c
+++ b/bin/interop-encode.c
@@ -359,7 +359,8 @@ main (int argc, char **argv)
                         exit(EXIT_FAILURE);
                     }
                 }
-                fprintf(stderr, "compression ratio: %.3f\n",
+                if (s_verbose)
+                    fprintf(stderr, "compression ratio: %.3f\n",
                         lsqpack_enc_ratio(&encoder));
                 write_enc_and_header_streams(out, stream_id, enc_buf, enc_off,
                                              pref_buf, pref_sz, hea_buf, hea_off);

--- a/test/test_qpack.c
+++ b/test/test_qpack.c
@@ -210,6 +210,7 @@ run_header_test (const struct qpack_header_block_test *test)
     size_t nw;
     int s;
     enum lsqpack_enc_status enc_st;
+    float ratio;
 
     s = lsqpack_enc_init(&enc, stderr, test->qhbt_table_size,
                 test->qhbt_table_size, test->qhbt_max_risked_streams,
@@ -266,6 +267,7 @@ run_header_test (const struct qpack_header_block_test *test)
     assert(0 == memcmp(test->qhbt_enc_buf, enc_buf, enc_off));
     assert(header_off == test->qhbt_header_sz);
     assert(0 == memcmp(test->qhbt_header_buf, header_buf, header_off));
+    assert(lsqpack_enc_ratio(&enc) > 0.0);
 
     lsqpack_enc_cleanup(&enc);
 }


### PR DESCRIPTION
Add two print-out functions, `lsqpack_dec_print_table()` and `lsqpack_enc_ratio()`, to the interop files to count them during testing coverage.