### PR TITLE
[IMPROVE] Remove unnecessary else block after assert

### DIFF
--- a/include/lsqpack.h
+++ b/include/lsqpack.h
@@ -473,8 +473,8 @@ struct lsqpack_enc
 
         /* Number of at-risk references in this header block */
         unsigned            n_risked;
-        /* Number of headers in this header list that are in the history */
-        unsigned            n_hdr_in_hist;
+        /* Number of headers in this header list added to the history */
+        unsigned            n_hdr_added_to_hist;
         /* True if there are other header blocks with the same stream ID
          * that are at risk.  (This means we can risk this header block
          * as well.)

--- a/include/lsqpack.h
+++ b/include/lsqpack.h
@@ -473,8 +473,8 @@ struct lsqpack_enc
 
         /* Number of at-risk references in this header block */
         unsigned            n_risked;
-        /* Number of headers in this header list */
-        unsigned            n_headers;
+        /* Number of headers in this header list that are in the history */
+        unsigned            n_hdr_in_hist;
         /* True if there are other header blocks with the same stream ID
          * that are at risk.  (This means we can risk this header block
          * as well.)

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -1354,7 +1354,7 @@ lsqpack_enc_start_header (struct lsqpack_enc *enc, uint64_t stream_id,
     else
         E_INFO("could not allocate hinfo for stream %"PRIu64, stream_id);
     enc->qpe_cur_header.n_risked = 0;
-    enc->qpe_cur_header.n_hdr_in_hist = 0;
+    enc->qpe_cur_header.n_hdr_added_to_hist = 0;
     enc->qpe_cur_header.base_idx = enc->qpe_ins_count;
 
     /* Check if there are other header blocks with the same stream ID that
@@ -1731,8 +1731,8 @@ lsqpack_enc_encode (struct lsqpack_enc *enc,
     /* Add header to history if it exists */
     if (enc->qpe_hist)
     {
-        ++enc->qpe_cur_header.n_hdr_in_hist;
-        if (enc->qpe_cur_header.n_hdr_in_hist > enc->qpe_hist->ehi_nels)
+        ++enc->qpe_cur_header.n_hdr_added_to_hist;
+        if (enc->qpe_cur_header.n_hdr_added_to_hist > enc->qpe_hist->ehi_nels)
             qenc_grow_history(enc->qpe_hist);
         enc->qpe_hist_add(enc->qpe_hist, name_hash, nameval_hash);
     }

--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -416,8 +416,6 @@ qenc_grow_history (struct lsqpack_enc_hist *hist)
         hist->ehi_wrapped = 0;
         hist->ehi_idx = hist->ehi_nels;
     }
-    else
-        memcpy(els, hist->ehi_els, hist->ehi_idx);
     hist->ehi_nels = nelem;
     free(hist->ehi_els);
     hist->ehi_els = els;


### PR DESCRIPTION
In the `qenc_grow_history()` function there is an `assert` and an `else` that check the same thing. The `else` block is removed in this commit.