### PR TITLE
[IMPROVE] Remove unnecessary assert in enc_init()

### DIFF
--- a/src/lsqpack.c
+++ b/src/lsqpack.c
@@ -541,8 +541,6 @@ lsqpack_enc_init (struct lsqpack_enc *enc, void *logger_ctx,
     unsigned nbits = 2;
     unsigned i;
 
-    assert(dyn_table_size <= max_table_size);
-
     if (dyn_table_size > LSQPACK_MAX_DYN_TABLE_SIZE ||
         max_risked_streams > LSQPACK_MAX_MAX_RISKED_STREAMS ||
         dyn_table_size > max_table_size)


### PR DESCRIPTION
In the function `lsqpack_enc_init()`, there is an `assert` and an if statement that check for the same thing. The assert is removed since this function is part of the user API.