### PR TITLE
[IMPROVE] Add scenarios to test drainage area logic

### DIFF
--- a/bin/interop-encode.c
+++ b/bin/interop-encode.c
@@ -204,6 +204,22 @@ ack_stream (struct lsqpack_enc *encoder, uint64_t stream_id)
 
 
 static int
+sync_table (struct lsqpack_enc *encoder, uint64_t num_inserts)
+{
+    unsigned char *end_cmd;
+    unsigned char cmd[80];
+
+    if (s_verbose)
+        fprintf(stderr, "Sync table num inserts %"PRIu64"\n", num_inserts);
+
+    cmd[0] = 0x00;
+    end_cmd = lsqpack_enc_int(cmd, cmd + sizeof(cmd), num_inserts, 6);
+    assert(end_cmd > cmd);
+    return lsqpack_enc_decoder_in(encoder, cmd, end_cmd - cmd);
+}
+
+
+static int
 cancel_stream (struct lsqpack_enc *encoder, uint64_t stream_id)
 {
     unsigned char *end_cmd;
@@ -389,6 +405,8 @@ main (int argc, char **argv)
                     exit(EXIT_FAILURE);
                 }
             }
+            else if (1 == sscanf(line, "## %*[s] %u", &arg))
+                sync_table(&encoder, arg);
             else if (1 == sscanf(line, "## %*[c] %u", &arg))
                 cancel_stream(&encoder, arg);
             else if (1 == sscanf(line, "## %*[t] %u", &arg))

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -1982,6 +1982,11 @@ enc_proc_header_ack (struct lsqpack_enc *enc, uint64_t stream_id)
         if (stream_id == hinfo->qhi_stream_id &&
                 (!acked || hinfo->qhi_seqno < acked->qhi_seqno))
             acked = hinfo;
+    /*
+     * XXX if an ACK comes in while a header is being encoded, it will not
+     *     have any effect because the the `qhi_max_id` is 0 until the header
+     *     encoding is finished (see enc_end_header()).
+     */
 
     if (!acked)
         return -1;

--- a/lsqpack.h
+++ b/lsqpack.h
@@ -427,6 +427,9 @@ struct lsqpack_enc
     lsqpack_abs_id_t            qpe_ins_count;
     lsqpack_abs_id_t            qpe_max_acked_id;
     lsqpack_abs_id_t            qpe_last_tss;
+    /* The smallest absolute index in the dynamic table that the encoder
+     * will emit a reference for.
+     */
     lsqpack_abs_id_t            qpe_drain_idx;
 
     enum {

--- a/test/scenarios/drain-2.sce
+++ b/test/scenarios/drain-2.sce
@@ -1,0 +1,37 @@
+TABLE_SIZE=512
+ANNOTATIONS=1
+AGGRESSIVE=0
+RISKED_STREAMS=0
+IMMEDIATE_ACK=0
+QIF=$(cat<<'EOQ'
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+spire	must be repaired
+sainte-chapelle	is known as the kingdom of light
+notre	dame translates our to lady of paris
+iconography	poor peoples book
+## s 2
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+victor	hugo wrote the hunchback
+archdiocese	of paris
+twelve	million people visit annually
+coronation	of emperor napoleon
+most	famous gothic cathedral
+
+victor	hugo wrote the hunchback
+archdiocese	of paris
+twelve	million people visit annually
+coronation	of emperor napoleon
+most	famous gothic cathedral
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+EOQ
+)

--- a/test/scenarios/drain.sce
+++ b/test/scenarios/drain.sce
@@ -1,0 +1,37 @@
+TABLE_SIZE=512
+ANNOTATIONS=1
+AGGRESSIVE=0
+RISKED_STREAMS=0
+IMMEDIATE_ACK=0
+QIF=$(cat<<'EOQ'
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+spire	must be repaired
+sainte-chapelle	is known as the kingdom of light
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+## s 2
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+victor	hugo wrote the hunchback
+archdiocese	of paris
+twelve	million people visit annually
+coronation	of emperor napoleon
+most	famous gothic cathedral
+
+victor	hugo wrote the hunchback
+archdiocese	of paris
+twelve	million people visit annually
+coronation	of emperor napoleon
+most	famous gothic cathedral
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+notre	dame translates to our lady of paris
+iconography	poor peoples book
+
+EOQ
+)


### PR DESCRIPTION
This branch adds two scenarios to test the drainage area logic. It also modifies the test driver _interop-encode.c_ to give the ability to annotate with `table sync` state updates.