### PR TITLE
Propagate wincompat include directory to users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(LSQPACK_XXH)
 endif()
 
 if(MSVC)
-    target_include_directories(ls-qpack PRIVATE wincompat)
+    target_include_directories(ls-qpack PUBLIC wincompat)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
`sys/queue.h` is included in lsqpack.h so when linking against lsqpack, users will need to have wincompat in their list include directories as well.