### PR TITLE
Add `lsqpack_enc_cancel_header` which cancels an in-progress header block

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -1180,6 +1180,29 @@ lsqpack_enc_header_data_prefix_size (const struct lsqpack_enc *enc)
 }
 
 
+int 
+lsqpack_enc_cancel_header (struct lsqpack_enc *enc)
+{
+    /* No header has been started. */
+    if (!(enc->qpe_flags & LSQPACK_ENC_HEADER))
+        return -1;
+
+    /* Cancellation is not (yet) allowed if the dynamic table is used since 
+     * ls-qpack's state is changed when the dynamic table is used. 
+     */
+    if (enc->qpe_cur_header.hinfo && HINFO_IDS_SET(enc->qpe_cur_header.hinfo))
+        return -1;
+
+    if (enc->qpe_cur_header.hinfo) {
+        enc_free_hinfo(enc, enc->qpe_cur_header.hinfo);
+        enc->qpe_cur_header.hinfo = NULL;
+    }
+
+    enc->qpe_flags &= ~LSQPACK_ENC_HEADER;
+
+    return 0;
+}
+
 ssize_t
 lsqpack_enc_end_header (struct lsqpack_enc *enc, unsigned char *buf, size_t sz)
 {

--- a/lsqpack.h
+++ b/lsqpack.h
@@ -186,6 +186,13 @@ lsqpack_enc_encode (struct lsqpack_enc *,
     enum lsqpack_enc_flags);
 
 /**
+ * Cancel current header block. Cancellation is only allowed if the dynamic 
+ * table is not used. Returns 0 on success, -1 on failure.
+ */
+int 
+lsqpack_enc_cancel_header (struct lsqpack_enc *);
+
+/**
  * End current header block.  The Header Data Prefix is written to `buf'.
  *
  * Returns:


### PR DESCRIPTION
I also added a test which seems to work but I do get `qenc: info: could not allocate hinfo for stream 0` in the output. I'm not sure if this indicates a problem or not.