### PR TITLE
201905100953 improve test coverage

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -3319,16 +3319,19 @@ parse_header_data (struct lsqpack_dec *dec,
                 LFONR.nread = 0;
                 LFONR.str_off = 0;
                 LFONR.str_len = value;
-                LFONR.nalloc = value * 2;
                 if (LFONR.is_huffman)
                 {
+                    LFONR.nalloc = value + value / 2;
                     LFONR.dec_huff_state.resume = 0;
                     read_ctx->hbrc_parse_ctx_u.data.state
                                         = DATA_STATE_READ_LFONR_NAME_HUFFMAN;
                 }
                 else
+                {
+                    LFONR.nalloc = value;
                     read_ctx->hbrc_parse_ctx_u.data.state
                                         = DATA_STATE_READ_LFONR_NAME_PLAIN;
+                }
                 LFONR.name = malloc(LFONR.nalloc);
                 if (LFONR.name)
                     break;

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -4487,7 +4487,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
                 /* TODO: Check that the name is not larger than the max dynamic
                  * table capacity, for example.
                  */
-                WONR.alloced_len = WONR.str_len ? WONR.str_len * 2 : 16;
+                WONR.alloced_len = WONR.str_len ? WONR.str_len + WONR.str_len / 2 : 16;
                 size = sizeof(*new_entry) + WONR.alloced_len;
                 WONR.entry = malloc(size);
                 if (!WONR.entry)

--- a/test/scenarios/end-dst-2.sce
+++ b/test/scenarios/end-dst-2.sce
@@ -1,0 +1,14 @@
+# This scenario is designed to reach the 'case HUFF_DEC_END_DST'
+# in lsqpack_dec_enc_in().
+TABLE_SIZE=256
+AGGRESSIVE=0
+RISKED_STREAMS=0
+QIF=$(cat<<'EOQ'
+aaaaaaaaaaaaaaaaaaaaaaaaa	aaaa
+bbbbbbbbbbbbbbbbbbbbbbbbb	bbbb
+
+aaaaaaaaaaaaaaaaaaaaaaaaa	aaaa
+bbbbbbbbbbbbbbbbbbbbbbbbb	bbbb
+
+EOQ
+)

--- a/test/scenarios/end-dst.sce
+++ b/test/scenarios/end-dst.sce
@@ -1,0 +1,14 @@
+# This scenario is designed to reach the 'case HUFF_DEC_END_DST'
+# in parse_header_data() when Huffman encoding is turned on.
+TABLE_SIZE=256
+AGGRESSIVE=1
+RISKED_STREAMS=1
+QIF=$(cat<<'EOQ'
+aaaa	aaa
+aaaa	aaaaa
+aaaa	aaaaaaaa
+aaaa	aaaaaaaaaaaaa
+aaaa	aaaaaaaaaaaaaaaaaaaaa
+
+EOQ
+)


### PR DESCRIPTION
Reduce the initial allocation size for Huffman buffers and add two test scenarios to reach the missing HUFF_DEC_END_DST cases.