### PR TITLE
201905141217 improve test case

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -4532,16 +4532,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
             }
             break;
         case DEI_WONR_READ_NAME_PLAIN:
-            if (WONR.alloced_len < WONR.str_len)
-            {
-                WONR.alloced_len = WONR.str_len * 2;
-                entry = realloc(WONR.entry, sizeof(*WONR.entry)
-                                                        + WONR.alloced_len);
-                if (entry)
-                    WONR.entry = entry;
-                else
-                    return -1;
-            }
+            assert(WONR.alloced_len >= WONR.str_len);
             size = MIN((unsigned) (end - buf), WONR.str_len - WONR.str_off);
             memcpy(DTE_NAME(WONR.entry) + WONR.str_off, buf, size);
             WONR.str_off += size;
@@ -4611,10 +4602,8 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
                 WONR.str_off += hdr.n_dst;
                 break;
             case HUFF_DEC_END_DST:
-                if (WONR.alloced_len)
-                    WONR.alloced_len *= 2;
-                else
-                    WONR.alloced_len = WONR.str_len + WONR.str_len / 4;
+                assert(WONR.alloced_len);
+                WONR.alloced_len *= 2;
                 entry = realloc(WONR.entry, sizeof(*WONR.entry)
                                                         + WONR.alloced_len);
                 if (!entry)

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -4364,7 +4364,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
                     WINR.name = DTE_NAME(WINR.reffed_entry);
                 }
                 if (WINR.is_huffman)
-                    WINR.alloced_val_len = WINR.val_len + WINR.val_len / 4;
+                    WINR.alloced_val_len = WINR.val_len + WINR.val_len / 2;
                 else
                     WINR.alloced_val_len = WINR.val_len;
                 WINR.entry = malloc(sizeof(*WINR.entry) + WINR.name_len
@@ -4441,16 +4441,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
             }
             break;
         case DEI_WINR_READ_VALUE_PLAIN:
-            if (WINR.alloced_val_len < WINR.val_len)
-            {
-                WINR.alloced_val_len = WINR.val_len;
-                entry = realloc(WINR.entry, sizeof(*WINR.entry)
-                                                        + WINR.alloced_val_len);
-                if (entry)
-                    WINR.entry = entry;
-                else
-                    return -1;
-            }
+            assert(WINR.alloced_val_len >= WINR.val_len);
             size = MIN((unsigned) (end - buf), WINR.val_len - WINR.val_off);
             memcpy(DTE_VALUE(WINR.entry) + WINR.val_off, buf, size);
             WINR.val_off += size;

--- a/test/test_read_enc_stream.c
+++ b/test/test_read_enc_stream.c
@@ -116,6 +116,24 @@ static const struct test_read_encoder_stream tests[] =
         },
     },
 
+    {   __LINE__,
+        "\x40\x88\xcc\x6a\x0d\x48\xea\xe8\x3b\x0f",
+        10,
+        1,
+        {
+            { "", "Kilimanjaro", },
+        },
+    },
+
+    {   __LINE__,
+        "\x43\x7a\x7a\x7a\x00",
+        5,
+        1,
+        {
+            { "zzz", "", },
+        },
+    },
+
 };
 
 

--- a/test/test_read_enc_stream.c
+++ b/test/test_read_enc_stream.c
@@ -134,6 +134,15 @@ static const struct test_read_encoder_stream tests[] =
         },
     },
 
+    {   __LINE__,
+        "\x40\x00",
+        2,
+        1,
+        {
+            { "", "", },
+        },
+    },
+
 };
 
 


### PR DESCRIPTION
Turn unreachable code for WINR and WONR into asserts. Add test cases for zero-len names and values for decoder.