### PR TITLE
README: add rust bindings as external library wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ for wrapping into a library for a higher-level language.  As of this writing, we
 know of the following wrappers:
 - Go: [ls-qpack-go](https://github.com/mpiraux/ls-qpack-go)
 - Python: [pylsqpack](https://github.com/aiortc/pylsqpack)
+- Rust: [ls-qpack-rs](https://github.com/BiagioFesta/ls-qpack-rs)
 - TypeScript: [quicker](https://github.com/rmarx/quicker/tree/draft-20/lib/ls-qpack)
 
 ## Versioning


### PR DESCRIPTION
I have created a Rust library which implements a idiomatic Rust wrapper around this library.

The library is public and distributed over [`crates.io`](https://crates.io/crates/ls-qpack) with [public documentation](https://docs.rs/ls-qpack/0.1.0-alpha/ls_qpack/).

This PR would add that reference to the list of existing wrappers.

Feel free to reject/close this PR; any feedback is more than welcome.

Thank you