### PR TITLE
CMakeLists.txt: Add compatibility with mingw64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(LSQPACK_XXH)
     target_sources(ls-qpack PRIVATE deps/xxhash/xxhash.c)
 endif()
 
-if(MSVC)
+if(WIN32)
     target_include_directories(ls-qpack PUBLIC wincompat)
 endif()
 
@@ -104,6 +104,6 @@ endif()
 
 install(TARGETS ls-qpack)
 install(FILES lsqpack.h lsxpack_header.h DESTINATION include)
-if(MSVC)
+if(WIN32)
     install(DIRECTORY wincompat/sys DESTINATION include)
 endif()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -5,7 +5,7 @@ function(lsqpack_add_executable TARGET)
     target_sources(${TARGET} PRIVATE ${TARGET}.c ../deps/xxhash/xxhash.c)
     target_include_directories(${TARGET} PRIVATE ../deps/xxhash)
 
-    if(MSVC)
+    if(WIN32)
         target_include_directories(${TARGET} PRIVATE ../wincompat)
         target_link_libraries(${TARGET} PRIVATE ${GETOPT_LIB})
     else()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ function(lsqpack_add_test TARGET)
     target_sources(test_${TARGET} PRIVATE test_${TARGET}.c)
     target_link_libraries(test_${TARGET} ls-qpack)
 
-    if(MSVC)
+    if(WIN32)
         target_include_directories(test_${TARGET} PRIVATE ../wincompat)
         target_link_libraries(test_${TARGET} ${GETOPT_LIB})
     else()


### PR DESCRIPTION
When building with mingw64, `<sys/queue.h>` isn't found. This is because the cmakefiles are including the `wincompat` folder only when using MSVC.

The patch includes the folder when building for win32, including mingw64.

Tested when cross building from Linux. MSVC build hasn't been tested.