### PR TITLE
Make fallthroughs explicit in lsqpack.c

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -2460,7 +2460,7 @@ lsqpack_enc_decoder_in (struct lsqpack_enc *enc,
                 prefix_bits = 6;
                 enc->qpe_dec_stream_state.handler = enc_proc_stream_cancel;
             }
-            /* fall through */
+            __attribute__((fallthrough));
         case 1:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &val,
                                 &enc->qpe_dec_stream_state.dec_int_state);
@@ -3624,7 +3624,7 @@ parse_header_data (struct lsqpack_dec *dec,
             prefix_bits = 7;
             DATA.dec_int_state.resume = 0;
             DATA.state = DATA_STATE_READ_VAL_LEN;
-            /* Fall-through */
+            __attribute__((fallthrough));
         case DATA_STATE_READ_VAL_LEN:
             r = lsqpack_dec_int24(&buf, end, prefix_bits, &DATA.left,
                                                         &DATA.dec_int_state);
@@ -3820,8 +3820,8 @@ parse_header_data (struct lsqpack_dec *dec,
             else
                 RETURN_ERROR();
             break;
-        case DATA_STATE_BEGIN_READ_LFPBNR_VAL_LEN: /* fall through */
-        case DATA_STATE_READ_LFPBNR_VAL_LEN: /* fall through */
+        case DATA_STATE_BEGIN_READ_LFPBNR_VAL_LEN: __attribute__((fallthrough));
+        case DATA_STATE_READ_LFPBNR_VAL_LEN: __attribute__((fallthrough));
         default:
             assert(0);
             RETURN_ERROR();
@@ -3905,7 +3905,7 @@ parse_header_prefix (struct lsqpack_dec *dec,
             DELB.dec_int_state.resume = 0;
             read_ctx->hbrc_parse_ctx_u.prefix.state =
                                             PREFIX_STATE_READ_LARGEST_REF;
-            /* Fall-through */
+            __attribute__((fallthrough));
         case PREFIX_STATE_READ_LARGEST_REF:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &RIC.value,
                                                         &RIC.dec_int_state);
@@ -3949,7 +3949,7 @@ parse_header_prefix (struct lsqpack_dec *dec,
             prefix_bits = 7;
             read_ctx->hbrc_parse_ctx_u.prefix.state =
                                             PREFIX_STATE_READ_DELTA_BASE_IDX;
-            /* Fall-through */
+            __attribute__((fallthrough));
         case PREFIX_STATE_READ_DELTA_BASE_IDX:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &DELB.value,
                                                         &DELB.dec_int_state);
@@ -4822,7 +4822,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
             WONR.dec_int_state.resume = 0;
             dec->qpd_enc_state.resume = DEI_WONR_READ_VAL_LEN;
             prefix_bits = 7;
-            /* fall-through */
+            __attribute__((fallthrough));
         case DEI_WONR_READ_VAL_LEN:
             r = lsqpack_dec_int24(&buf, end, prefix_bits, &WONR.str_len,
                                                         &WONR.dec_int_state);
@@ -5127,14 +5127,14 @@ qenc_huffman_enc (const unsigned char *src, const unsigned char *const src_end,
         switch (adj >> 3)
         {                               /* Write out */
 #if UINTPTR_MAX == 18446744073709551615ull
-        case 8: *dst++ = (unsigned char)(bits >> 56);
-        case 7: *dst++ = (unsigned char)(bits >> 48);
-        case 6: *dst++ = (unsigned char)(bits >> 40);
-        case 5: *dst++ = (unsigned char)(bits >> 32);
+        case 8: *dst++ = (unsigned char)(bits >> 56); __attribute__((fallthrough));
+        case 7: *dst++ = (unsigned char)(bits >> 48); __attribute__((fallthrough));
+        case 6: *dst++ = (unsigned char)(bits >> 40); __attribute__((fallthrough));
+        case 5: *dst++ = (unsigned char)(bits >> 32); __attribute__((fallthrough));
 #endif
-        case 4: *dst++ = (unsigned char)(bits >> 24);
-        case 3: *dst++ = (unsigned char)(bits >> 16);
-        case 2: *dst++ = (unsigned char)(bits >> 8);
+        case 4: *dst++ = (unsigned char)(bits >> 24); __attribute__((fallthrough));
+        case 3: *dst++ = (unsigned char)(bits >> 16); __attribute__((fallthrough));
+        case 2: *dst++ = (unsigned char)(bits >> 8);  __attribute__((fallthrough));
         default: *dst++ = (unsigned char)bits;
         }
     }
@@ -5225,9 +5225,11 @@ huff_decode_fast (const unsigned char *src, int src_len,
             case 8:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
+                __attribute__((fallthrough));
             case 7:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
+                __attribute__((fallthrough));
             default:
                 buf <<= 48;
                 buf |= (uintptr_t) *src++ << 40;
@@ -5238,9 +5240,11 @@ huff_decode_fast (const unsigned char *src, int src_len,
             case 4:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
+                __attribute__((fallthrough));
             case 3:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
+                __attribute__((fallthrough));
             default:
                 buf <<= 16;
 #endif

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -60,6 +60,8 @@ SOFTWARE.
 #    else
 #      define deliberate_fallthrough
 #    endif
+#  else
+#    define deliberate_fallthrough
 #  endif
 #endif
 

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -53,6 +53,16 @@ SOFTWARE.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+#ifndef deliberate_fallthrough
+#  if defined __has_attribute
+#    if __has_attribute (fallthrough)
+#      define deliberate_fallthrough __attribute__ ((fallthrough))
+#    else
+#      define deliberate_fallthrough
+#    endif
+#  endif
+#endif
+
 static unsigned char *
 qenc_huffman_enc (const unsigned char *, const unsigned char *const, unsigned char *);
 
@@ -2460,7 +2470,7 @@ lsqpack_enc_decoder_in (struct lsqpack_enc *enc,
                 prefix_bits = 6;
                 enc->qpe_dec_stream_state.handler = enc_proc_stream_cancel;
             }
-            __attribute__((fallthrough));
+            deliberate_fallthrough;
         case 1:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &val,
                                 &enc->qpe_dec_stream_state.dec_int_state);
@@ -3624,7 +3634,7 @@ parse_header_data (struct lsqpack_dec *dec,
             prefix_bits = 7;
             DATA.dec_int_state.resume = 0;
             DATA.state = DATA_STATE_READ_VAL_LEN;
-            __attribute__((fallthrough));
+            deliberate_fallthrough;
         case DATA_STATE_READ_VAL_LEN:
             r = lsqpack_dec_int24(&buf, end, prefix_bits, &DATA.left,
                                                         &DATA.dec_int_state);
@@ -3820,8 +3830,8 @@ parse_header_data (struct lsqpack_dec *dec,
             else
                 RETURN_ERROR();
             break;
-        case DATA_STATE_BEGIN_READ_LFPBNR_VAL_LEN: __attribute__((fallthrough));
-        case DATA_STATE_READ_LFPBNR_VAL_LEN: __attribute__((fallthrough));
+        case DATA_STATE_BEGIN_READ_LFPBNR_VAL_LEN:
+        case DATA_STATE_READ_LFPBNR_VAL_LEN:
         default:
             assert(0);
             RETURN_ERROR();
@@ -3905,7 +3915,7 @@ parse_header_prefix (struct lsqpack_dec *dec,
             DELB.dec_int_state.resume = 0;
             read_ctx->hbrc_parse_ctx_u.prefix.state =
                                             PREFIX_STATE_READ_LARGEST_REF;
-            __attribute__((fallthrough));
+            deliberate_fallthrough;
         case PREFIX_STATE_READ_LARGEST_REF:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &RIC.value,
                                                         &RIC.dec_int_state);
@@ -3949,7 +3959,7 @@ parse_header_prefix (struct lsqpack_dec *dec,
             prefix_bits = 7;
             read_ctx->hbrc_parse_ctx_u.prefix.state =
                                             PREFIX_STATE_READ_DELTA_BASE_IDX;
-            __attribute__((fallthrough));
+            deliberate_fallthrough;
         case PREFIX_STATE_READ_DELTA_BASE_IDX:
             r = lsqpack_dec_int(&buf, end, prefix_bits, &DELB.value,
                                                         &DELB.dec_int_state);
@@ -4822,7 +4832,7 @@ lsqpack_dec_enc_in (struct lsqpack_dec *dec, const unsigned char *buf,
             WONR.dec_int_state.resume = 0;
             dec->qpd_enc_state.resume = DEI_WONR_READ_VAL_LEN;
             prefix_bits = 7;
-            __attribute__((fallthrough));
+            deliberate_fallthrough;
         case DEI_WONR_READ_VAL_LEN:
             r = lsqpack_dec_int24(&buf, end, prefix_bits, &WONR.str_len,
                                                         &WONR.dec_int_state);
@@ -5127,14 +5137,14 @@ qenc_huffman_enc (const unsigned char *src, const unsigned char *const src_end,
         switch (adj >> 3)
         {                               /* Write out */
 #if UINTPTR_MAX == 18446744073709551615ull
-        case 8: *dst++ = (unsigned char)(bits >> 56); __attribute__((fallthrough));
-        case 7: *dst++ = (unsigned char)(bits >> 48); __attribute__((fallthrough));
-        case 6: *dst++ = (unsigned char)(bits >> 40); __attribute__((fallthrough));
-        case 5: *dst++ = (unsigned char)(bits >> 32); __attribute__((fallthrough));
+        case 8: *dst++ = (unsigned char)(bits >> 56); deliberate_fallthrough;
+        case 7: *dst++ = (unsigned char)(bits >> 48); deliberate_fallthrough;
+        case 6: *dst++ = (unsigned char)(bits >> 40); deliberate_fallthrough;
+        case 5: *dst++ = (unsigned char)(bits >> 32); deliberate_fallthrough;
 #endif
-        case 4: *dst++ = (unsigned char)(bits >> 24); __attribute__((fallthrough));
-        case 3: *dst++ = (unsigned char)(bits >> 16); __attribute__((fallthrough));
-        case 2: *dst++ = (unsigned char)(bits >> 8);  __attribute__((fallthrough));
+        case 4: *dst++ = (unsigned char)(bits >> 24); deliberate_fallthrough;
+        case 3: *dst++ = (unsigned char)(bits >> 16); deliberate_fallthrough;
+        case 2: *dst++ = (unsigned char)(bits >> 8);  deliberate_fallthrough;
         default: *dst++ = (unsigned char)bits;
         }
     }
@@ -5225,11 +5235,11 @@ huff_decode_fast (const unsigned char *src, int src_len,
             case 8:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
-                __attribute__((fallthrough));
+                deliberate_fallthrough;
             case 7:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
-                __attribute__((fallthrough));
+                deliberate_fallthrough;
             default:
                 buf <<= 48;
                 buf |= (uintptr_t) *src++ << 40;
@@ -5240,11 +5250,11 @@ huff_decode_fast (const unsigned char *src, int src_len,
             case 4:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
-                __attribute__((fallthrough));
+                deliberate_fallthrough;
             case 3:
                 buf <<= 8;
                 buf |= (uintptr_t) *src++;
-                __attribute__((fallthrough));
+                deliberate_fallthrough;
             default:
                 buf <<= 16;
 #endif


### PR DESCRIPTION
Using `__attribute__((fallthrough));` informs the compiler, in a way it understands, that the fallthrough is explicit and wanted.

This allows for the enablement of `-Wimplicit-fallthrough`, which throws warnings/errors for implicit fallthroughs, of which several exist in this file. Using `-Wimplicit-fallthrough` prevents unwanted fallthroughs.