### PR TITLE
CMakeLists: do not install bins if option is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,12 +134,15 @@ install(
 )
 install(FILES lsqpack.h lsxpack_header.h
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/bin/encode-int
-        ${CMAKE_CURRENT_BINARY_DIR}/bin/fuzz-decode
-        ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-decode
-        ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-encode
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if(LSQPACK_BIN)
+    install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/bin/encode-int
+          ${CMAKE_CURRENT_BINARY_DIR}/bin/fuzz-decode
+          ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-decode
+          ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-encode
+          DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if(WIN32)
     install(DIRECTORY wincompat/sys DESTINATION include)


### PR DESCRIPTION
This fixes cmake installation directives:

```
$ cmake -DLSQPACK_BIN=OFF .....

CMake Error at cmake_install.cmake:80 (file):
  file INSTALL cannot find
  "[...]/ls-qpack/build.d/bin/encode-int": No such file or
  directory.
```