### PR TITLE
Fix compiler errors when built with C++ modules using clang

### DIFF
--- a/lsqpack.h
+++ b/lsqpack.h
@@ -29,10 +29,6 @@ SOFTWARE.
 #ifndef LSQPACK_H
 #define LSQPACK_H 1
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -40,6 +36,10 @@ extern "C" {
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define LSQPACK_MAJOR_VERSION 2
@@ -616,12 +616,20 @@ enum lsqpack_tnv
     LSQPACK_TNV_X_FRAME_OPTIONS_SAMEORIGIN = 98, /* "x-frame-options" "sameorigin" */
 };
 
+#ifdef __cplusplus
+}
+#endif
+
 
 /*
  * Internals follow.  The internals are subject to change without notice.
  */
 
 #include <sys/queue.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* It takes 11 bytes to encode UINT64_MAX as HPACK integer */
 #define LSQPACK_UINT64_ENC_SZ 11u

--- a/lsxpack_header.h
+++ b/lsxpack_header.h
@@ -1,13 +1,13 @@
 #ifndef LSXPACK_HEADER_H_v208
 #define LSXPACK_HEADER_H_v208
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef LSXPACK_MAX_STRLEN
 #define LSXPACK_MAX_STRLEN UINT16_MAX


### PR DESCRIPTION
```
ls-qpack/lsqpack.h:36:1: error: import of C++ module '_Builtin_limits' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   36 | #include <limits.h>
      | ^
ls-qpack/lsqpack.h:33:1: note: extern "C" language linkage specification begins here
   33 | extern "C" {
      | ^
ls-qpack/lsqpack.h:37:1: error: import of C++ module 'std_stdint_h' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   37 | #include <stdint.h>
      | ^
ls-qpack/lsqpack.h:33:1: note: extern "C" language linkage specification begins here
   33 | extern "C" {
      | ^
ls-qpack/lsqpack.h:624:1: error: import of C++ module 'Darwin.sys.queue' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
  624 | #include <sys/queue.h>
      | ^
ls-qpack/lsqpack.h:33:1: note: extern "C" language linkage specification begins here
   33 | extern "C" {
      | ^
ls-qpack/lsxpack_header.h:9:1: error: import of C++ module 'std_stdint_h' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
    9 | #include <stdint.h>
      | ^
ls-qpack/lsxpack_header.h:5:1: note: extern "C" language linkage specification begins here
    5 | extern "C" {
      | ^
ls-qpack/lsxpack_header.h:10:1: error: import of C++ module 'std_string_h' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   10 | #include <string.h>
      | ^
ls-qpack/lsxpack_header.h:5:1: note: extern "C" language linkage specification begins here
    5 | extern "C" {
      | ^
```