### PR TITLE
Fix: infinite loop in parse_header_data() when HTTP/3 header length exceeds 65535

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -3318,7 +3318,7 @@ header_out_grow_buf (struct lsqpack_dec *dec,
         size = 2;
     need = read_ctx->hbrc_out.xhdr->val_len + size / 2;
     if (need > LSXPACK_MAX_STRLEN)
-        need = LSXPACK_MAX_STRLEN;
+        return -1;
     read_ctx->hbrc_out.xhdr = dec->qpd_dh_if->dhi_prepare_decode(
                         read_ctx->hbrc_hblock, read_ctx->hbrc_out.xhdr, need);
     if (!read_ctx->hbrc_out.xhdr)


### PR DESCRIPTION
### Issue Description
When using QPACK for encoding and decoding in HTTP/3, lsquic encounters **infinite loop** during the process of decoding client request headers.

### Loop Description
Infinite loop occurs in `parse_header_data()`. Loop is as follows:
1. `get_dst()`: Unable to store Huffman decoding results due to insufficient buffer space.
2. `lsqpack_huff_decode()`: Returns status code HUFF_DEC_END_DST, indicating the buffer is full.
3. `header_out_grow_buf()`: Attempts to calculate the required buffer growth size but restricts it to a maximum limit.
4. `h1h_prepare_decode()`: Fails to grow the buffer because the size remains unchanged.
1. `get_dst()`: Unable to store Huffman decoding results due to insufficient buffer space.
......  loop continues.

### Loop Reason
During the decoding of HTTP/3 request header, if the buffer space is insufficient, a buffer expansion is triggered. However, even if the **required expansion size exceeds 65535 bytes**, the `header_out_grow_buf()` **restricts the buffer size to 65535 bytes**, **resulting in no additional space being allocated.** This causes the decoding process to enter a infinite loop.