### PR TITLE
CMake: Fix exported pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,8 @@ endif()
 
 include(GNUInstallDirs)
 configure_file(lsqpack.pc.in lsqpack.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lsqpack.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 install(TARGETS ls-qpack EXPORT ls-qpack-config
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -146,7 +148,4 @@ endif()
 
 if(WIN32)
     install(DIRECTORY wincompat/sys DESTINATION include)
-else()
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lsqpack.pc"
-	    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/lsqpack.pc.in
+++ b/lsqpack.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @LSQPACK_DEPENDS@
+Requires.private: @LSQPACK_DEPENDS@
 Cflags: -I"${includedir}"
-Libs: -L"${libdir}" -llsqpack
+Libs: -L"${libdir}" -lls-qpack


### PR DESCRIPTION
Install for all targets. (There `pkgconf --msvc-syntax`.)
The libname is `ls-qpack`.
`LSQPACK_DEPENDS` carries xxhash which is a private (link) dependency.