### PR TITLE
Add alias target ls-qpack::ls-qpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(BUILD_SHARED_LIBS OFF)
 
 # Use `cmake -DBUILD_SHARED_LIBS=OFF` to build a static library.
 add_library(ls-qpack "")
+add_library(ls-qpack::ls-qpack ALIAS ls-qpack)
 set_target_properties(ls-qpack PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	SOVERSION ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
#59 added CMake config export of the namespaced target ls-qpack::ls-qpack which is recommended practice. 

This PR complements that change by offering the same target name by an alias. This allows a uniform `target_link_libraries` usage pattern regardless of ls-qpack being integrated via `add_subdirectory` (e.g. in pristine msh3) or as an external CMake package (e.g. in vcpkg port msh3). It also promotes recognizing `lsqpack::lsqpack` as an external CMake target (vs. a plain `lsqack`),