### PR TITLE
Fix binary rpath handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,12 +147,12 @@ install(FILES lsqpack.h lsxpack_header.h
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(LSQPACK_BIN)
-    install(FILES
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/encode-int
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/fuzz-decode
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-decode
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/interop-encode
-          DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS
+            encode-int
+            fuzz-decode
+            interop-decode
+            interop-encode
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if(WIN32 OR EMSCRIPTEN)


### PR DESCRIPTION
Binaries should be installed using `install(TARGETS ... RUNTIME)` instead of `install(FILES)`, so that CMake properly handles runtime path stripping.

Before the fix:
```
# cmake -DBUILD_SHARED_LIBS=yes -B build && cmake --build build && cmake --install build
# scanelf -r /usr/local/bin/interop-encode 
 TYPE   RPATH FILE 
ET_DYN /ls-qpack/build /usr/local/bin/interop-encode
```

After the fix:
```
# scanelf -r /usr/local/bin/interop-encode 
 TYPE   RPATH FILE 
ET_DYN   -   /usr/local/bin/interop-encode
```