### PR TITLE
Fix endianness issue on pylsqpack in s390x

### DIFF
--- a/lsqpack.c
+++ b/lsqpack.c
@@ -37,6 +37,7 @@ SOFTWARE.
 #include <string.h>
 #include <sys/queue.h>
 #include <sys/types.h>
+#include <endian.h>
 #include <inttypes.h>
 
 #include "lsqpack.h"

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -41,6 +41,7 @@ SOFTWARE.
 
 #ifndef WIN32
 #include <endian.h>
+#endif
 
 #include "lsqpack.h"
 #include "lsxpack_header.h"

--- a/lsqpack.c
+++ b/lsqpack.c
@@ -37,8 +37,10 @@ SOFTWARE.
 #include <string.h>
 #include <sys/queue.h>
 #include <sys/types.h>
-#include <endian.h>
 #include <inttypes.h>
+
+#ifndef WIN32
+#include <endian.h>
 
 #include "lsqpack.h"
 #include "lsxpack_header.h"


### PR DESCRIPTION
The python library [pylsqpack](https://github.com/aiortc/pylsqpack) uses c99 standards to compile `ls-qpack`.
In `huff-tables.h` the following logic is present
```
#if __BYTE_ORDER == __LITTLE_ENDIAN
#define I(i,j) ((j<<8)|i)
#else
#define I(i,j) ((i<<8)|j)
#endif
```
But the macros `__BYTE_ORDER` and `__LITTLE_ENDIAN` are defined in `endian.h` header file.
This gets automatically included for gnu standards but does not automatically get included for c standards.
So, for c99 `__BYTE_ORDER` and `__LITTLE_ENDIAN` are not defined if `endian.h` is not included.
So, `#if __BYTE_ORDER == __LITTLE_ENDIAN` becomes `#if NULL == NULL` which always evaluates
to `true`.
This will not cause an issue for little endian systems. But is causing issues for big endian systems like s390x.