### PR TITLE
CMake: build binaries with LSQPACK_TESTS as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,8 @@ if(LSQPACK_TESTS)
     add_subdirectory(test)
 endif()
 
-if(LSQPACK_BIN)
+# The executables are used within the test suite as well.
+if(LSQPACK_BIN OR LSQPACK_TESTS)
     add_subdirectory(bin)
 endif()
 


### PR DESCRIPTION
Build the binaries with `-DLSQPACK_TESTS=ON`, to ensure that the test suite works even if they are not meant to be installed (via `-DLSQPACK_BIN=OFF`).