### PR TITLE
Fix running test_dyn_table_cap_mismatch from arbitrary location

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_compile_definitions("TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/testdata\"")
+
 function(lsqpack_add_test TARGET)
     add_executable(test_${TARGET} "")
     target_sources(test_${TARGET} PRIVATE test_${TARGET}.c)

--- a/test/test_dyn_table_cap_mismatch.c
+++ b/test/test_dyn_table_cap_mismatch.c
@@ -36,8 +36,8 @@ int main(int argc, const char * argv[]) {
     size_t size = 0;
     if (!encoder_stream)
     {
-        encoder_stream = fopen("../../test/testdata/encoder_stream", "r");
-        response = fopen("../../test/testdata/response", "r");
+        encoder_stream = fopen(TEST_DATA "/encoder_stream", "r");
+        response = fopen(TEST_DATA "/response", "r");
     }
     while ((size = fread(buffer, 1, sizeof(buffer), encoder_stream)) > 0) {
         lsqpack_dec_enc_in(&qpackDecoder, buffer, size);


### PR DESCRIPTION
Do not hardwire assumptions about the source directory in `test_dyn_table_cap_mismatch`, in order to fix running tests when the build directory is not a direct subdirectory of the source directory.  Instead, pass the test data directory straight from CMake via a preprocessor definition.